### PR TITLE
Add test code for decodable

### DIFF
--- a/Sources/ApiReachable.swift
+++ b/Sources/ApiReachable.swift
@@ -96,7 +96,7 @@ public extension ApiReachable where Self: BaseMappable {
 }
 
 
-public extension ApiReachable where Self: Codable {
+public extension ApiReachable where Self: Decodable {
     
     static func reach(method: HTTPMethod,
                       queries: [String: Any] = [:],


### PR DESCRIPTION
- ApiReachable.reach protocol condition Codable -> Decodable
- struct name changed
	- MappableItuensSearchResultItem -> ItuenseSearchItem
- add decodable protocol
	- Genre
	- ItuenseSearchItem
- add test code for decodable